### PR TITLE
Adding license headers, fixing directory, and reverting back to Go

### DIFF
--- a/quickstart-automate/cloudbuild.yaml
+++ b/quickstart-automate/cloudbuild.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
-  - name: python
-    args: ['python', 'main.py']
+  - name: golang
+    args: ['go', 'run', 'quickstart-automate/main.go']

--- a/quickstart-automate/main.go
+++ b/quickstart-automate/main.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+"fmt"
+)
+
+func main () {
+  fmt.Println("Hello, world!")
+}

--- a/quickstart-automate/main.py
+++ b/quickstart-automate/main.py
@@ -1,2 +1,0 @@
-print("Hello World!")
-


### PR DESCRIPTION
License headers
Fixing directory in cloudbuild.yaml
Reverting back to golang