### PR TITLE
Adding golang sample

### DIFF
--- a/golang-sample/Dockerfile
+++ b/golang-sample/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the offical golang image to create a binary.
+# This is based on Debian and sets the GOPATH to /go.
+# https://hub.docker.com/_/golang
+FROM golang:1.16-buster as builder
+
+# Create and change to the app directory.
+WORKDIR /app
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+# Expecting to copy go.mod and if present go.sum.
+COPY go.* ./
+RUN go mod download
+
+# Copy local code to the container image.
+COPY . ./
+
+# Build the binary.
+RUN go build -v -o server
+
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the binary to the production image from the builder stage.
+COPY --from=builder /app/server /app/server
+
+# Run the web service on container startup.
+CMD ["/app/server"]

--- a/golang-sample/cloudbuild.yaml
+++ b/golang-sample/cloudbuild.yaml
@@ -36,8 +36,7 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['run', 'deploy', 'helloworld', 
            '--image=us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA', 
-           '--region', 'us-central1', '--platform', 'managed', 
-           '--allow-unauthenticated']
+           '--region', 'us-central1', '--platform', 'managed']
 
 # Save test logs to Google Cloud Storage
 artifacts:

--- a/golang-sample/cloudbuild.yaml
+++ b/golang-sample/cloudbuild.yaml
@@ -13,25 +13,15 @@
 # limitations under the License.
 
 steps:
-  # Initialize the module
-  - name: golang
-    args: ['go', 'mod', 'init', 'github.com/GoogleCloudPlatform/cloud-build-samples/golang']
-
-  # Clean up dependencies
-  - name: golang
-    args: ['go', 'mod', 'tidy']
-
-  # Build application
-  - name: golang
-    args: ['go', 'build', '.']
-
   # Run tests and save to file
   - name: golang
     entrypoint: /bin/bash
     args: 
       - -c
       - |
-        go test . -v -json > ${SHORT_SHA}_test_log.json
+        go get -u github.com/jstemmer/go-junit-report
+        2>&1 go test -timeout 1m -v "${1:-./...}" | tee sponge.log
+        /go/bin/go-junit-report -set-exit-code < sponge.log > ${SHORT_SHA}_test_log.xml
 
   # Docker Build
   - name: 'gcr.io/cloud-builders/docker'
@@ -40,7 +30,7 @@ steps:
 
   # Docker push to Google Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push',  'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA']
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA']
 
   # Deploy to Cloud Run
   - name: google/cloud-sdk
@@ -54,7 +44,7 @@ artifacts:
   objects:
     location: gs://$_BUCKET_NAME/
     paths:
-      - ${SHORT_SHA}_test_log.json
+      - ${SHORT_SHA}_test_log.xml
 
 # Store images in Google Artifact Registry
 images:

--- a/golang-sample/cloudbuild.yaml
+++ b/golang-sample/cloudbuild.yaml
@@ -33,8 +33,8 @@ steps:
     args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA']
 
   # Deploy to Cloud Run
-  - name: google/cloud-sdk
-    args: ['gcloud', 'run', 'deploy', 'helloworld', 
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args: ['run', 'deploy', 'helloworld', 
            '--image=us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA', 
            '--region', 'us-central1', '--platform', 'managed', 
            '--allow-unauthenticated']

--- a/golang-sample/cloudbuild.yaml
+++ b/golang-sample/cloudbuild.yaml
@@ -1,0 +1,61 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Initialize the module
+  - name: golang
+    args: ['go', 'mod', 'init', 'github.com/GoogleCloudPlatform/cloud-build-samples/golang']
+
+  # Clean up dependencies
+  - name: golang
+    args: ['go', 'mod', 'tidy']
+
+  # Build application
+  - name: golang
+    args: ['go', 'build', '.']
+
+  # Run tests and save to file
+  - name: golang
+    entrypoint: /bin/bash
+    args: 
+      - -c
+      - |
+        go test . -v -json > ${SHORT_SHA}_test_log.json
+
+  # Docker Build
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 
+           'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA', '.']
+
+  # Docker push to Google Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push',  'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA']
+
+  # Deploy to Cloud Run
+  - name: google/cloud-sdk
+    args: ['gcloud', 'run', 'deploy', 'helloworld', 
+           '--image=us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA', 
+           '--region', 'us-central1', '--platform', 'managed', 
+           '--allow-unauthenticated']
+
+# Save test logs to Google Cloud Storage
+artifacts:
+  objects:
+    location: gs://$_BUCKET_NAME/
+    paths:
+      - ${SHORT_SHA}_test_log.json
+
+# Store images in Google Artifact Registry
+images:
+  - us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage:$SHORT_SHA

--- a/golang-sample/go.mod
+++ b/golang-sample/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/cloud-build-samples/golang
+
+go 1.15

--- a/golang-sample/main.go
+++ b/golang-sample/main.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Sample run-helloworld is a minimal Cloud Run service.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	log.Print("starting server...")
+	http.HandleFunc("/", handler)
+
+	// Determine port for HTTP service.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("defaulting to port %s", port)
+	}
+
+	// Start HTTP server.
+	log.Printf("listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	name := os.Getenv("NAME")
+	if name == "" {
+		name = "World"
+	}
+	fmt.Fprintf(w, "Hello %s!\n", name)
+}

--- a/golang-sample/main_test.go
+++ b/golang-sample/main_test.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	tests := []struct {
+		label string
+		want  string
+		name  string
+	}{
+		{
+			label: "default",
+			want:  "Hello World!\n",
+			name:  "",
+		},
+		{
+			label: "override",
+			want:  "Hello Override!\n",
+			name:  "Override",
+		},
+	}
+
+	originalName := os.Getenv("NAME")
+	defer os.Setenv("NAME", originalName)
+
+	for _, test := range tests {
+		os.Setenv("NAME", test.name)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if got := rr.Body.String(); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.label, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Following the logic of the python sample as closely as possible. 

Python code: https://github.com/GoogleCloudPlatform/cloud-build-samples/blob/main/python-example-flask/cloudbuild.yaml
Python documentation: https://cloud.google.com/build/docs/building/build-python

Current golang documentation: https://cloud.google.com/build/docs/building/build-go

Outstanding question:  Should the go mod init be done outside of the cloudbuild step? 