### PR TITLE
Add remote builder pattern.

### DIFF
--- a/remote-builder/README.md
+++ b/remote-builder/README.md
@@ -1,0 +1,45 @@
+# Remote builder pattern
+
+This is an example of how a parent build can kick off a child build, in this case to run a potentially more expensive build step for a shorter amount of time. 
+
+## Kicking off the parent build
+
+This will kick off the build defined in `parent-build.yaml`. 
+
+```
+gcloud builds submit --config=parent-build.yaml
+```
+
+## Running the child build as a step in the parent build
+
+The `parent-build.yaml` utilizes the gcloud container image to kick off the build defined in `child-build.yaml`. 
+
+It will then complete the remainder of the build upon successful completion of `child-build.yaml`. 
+
+```
+# parent-build.yaml
+
+steps:
+- name: 'bash'
+  id: bash-1
+  args:
+   - 'sleep'
+   - '30'
+
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  id: child-build
+  entrypoint: 'gcloud'
+  args:
+  - 'builds'
+  - 'submit'
+  - '--config'
+  - './child-build.yaml'
+  waitFor: ['bash-1']
+
+- name: 'bash'
+  id: bash-2
+  args:
+   - 'sleep'
+   - '30'
+  waitFor: ['child-build']
+  ```

--- a/remote-builder/child-build.yaml
+++ b/remote-builder/child-build.yaml
@@ -1,0 +1,8 @@
+steps:
+- name: 'bash'
+  args:
+   - 'sleep'
+   - '30'
+timeout: 40s
+options: 
+    machineType: 'N1_HIGHCPU_8'

--- a/remote-builder/child-build.yaml
+++ b/remote-builder/child-build.yaml
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 steps:
 - name: 'bash'
   args:

--- a/remote-builder/parent-build.yaml
+++ b/remote-builder/parent-build.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
 - name: 'bash'
   id: bash-1

--- a/remote-builder/parent-build.yaml
+++ b/remote-builder/parent-build.yaml
@@ -1,0 +1,23 @@
+steps:
+- name: 'bash'
+  id: bash-1
+  args:
+   - 'sleep'
+   - '30'
+
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  id: child-build
+  entrypoint: 'gcloud'
+  args:
+  - 'builds'
+  - 'submit'
+  - '--config'
+  - './child-build.yaml'
+  waitFor: ['bash-1']
+
+- name: 'bash'
+  id: bash-2
+  args:
+   - 'sleep'
+   - '30'
+  waitFor: ['child-build']


### PR DESCRIPTION
Open to feedback! I have worked with a handful of folks looking for examples on how to run a potentially more expensive build step separately from the rest of a given build to conserve costs. This pattern displays how to do so. 

(first time contributing here, so please let me know if there are other guidelines for adding examples. thank you!)