### PR TITLE
Remove script mode from tests

### DIFF
--- a/basic-config/test.cloudbuild.yaml
+++ b/basic-config/test.cloudbuild.yaml
@@ -1,12 +1,18 @@
 steps:
   - id: test-builds-successfully
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    script: |
-      cd basic-config
-      gcloud builds submit --config cloudbuild.yaml
+    dir: basic-config
+    entrypoint: /bin/bash
+    args: 
+      - '-c'
+      - |
+        gcloud builds submit --config cloudbuild.yaml
 
   - id: cleanup
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    script: |
-      gcloud compute instances delete my-vm-name --zone us-central1-a
-      gcloud artifacts docker images delete us-central1-docker.pkg.dev/${PROJECT_ID}/my-docker-repo/myimage
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gcloud compute instances delete my-vm-name --zone us-central1-a
+        gcloud artifacts docker images delete us-central1-docker.pkg.dev/${PROJECT_ID}/my-docker-repo/myimage

--- a/deploy-firebase-example/test.cloudbuild.yaml
+++ b/deploy-firebase-example/test.cloudbuild.yaml
@@ -1,18 +1,27 @@
 steps:
   - id: clone-install-builder
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    script: |
-      git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
-      cd cloud-builders-community/firebase
-      gcloud builds submit . --project $_TARGET_PROJECT
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
+        cd cloud-builders-community/firebase
+        gcloud builds submit . --project $_TARGET_PROJECT
 
   - id: test-builds-successfully
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     dir: deploy-firebase-example/
-    script: |
-      gcloud builds submit --config cloudbuild.yaml --project $_TARGET_PROJECT
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gcloud builds submit --config cloudbuild.yaml --project $_TARGET_PROJECT
 
   - id: cleanup-builder-image
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    script: |
-      gcloud container images delete gcr.io/$_TARGET_PROJECT/firebase --project $_TARGET_PROJECT
+    entrypoint: /bin/bash
+    args: 
+      - '-c'
+      -  |
+         gcloud container images delete gcr.io/$_TARGET_PROJECT/firebase --project $_TARGET_PROJECT

--- a/golang-sample/test.cloudbuild.yaml
+++ b/golang-sample/test.cloudbuild.yaml
@@ -2,17 +2,19 @@ steps:
   - id: test-builds-successfully
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     dir: golang-sample/
-    env:
-      - 'SHORT_SHA=$SHORT_SHA'
-    script: |
-      gcloud builds submit --config cloudbuild.yaml \
-      --substitutions SHORT_SHA=${SHORT_SHA},_REPO_NAME=${_REPO_NAME},_BUCKET_NAME=${_BUCKET_NAME}
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gcloud builds submit --config cloudbuild.yaml \
+        --substitutions SHORT_SHA=${SHORT_SHA},_REPO_NAME=${_REPO_NAME},_BUCKET_NAME=${_BUCKET_NAME}
 
   - id: cleanup
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    env:
-      - 'SHORT_SHA=$SHORT_SHA'
-    script: |
-      gsutil rm gs://${_BUCKET_NAME}/${SHORT_SHA}_test_log.xml
-      gcloud artifacts docker images delete us-central1-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/myimage:${SHORT_SHA}
-      gcloud run services delete helloworld-${SHORT_SHA} --region us-central1 --quiet
+    entrypoint: /bin/bash
+    args: 
+      - '-c'
+      - |
+        gsutil rm gs://${_BUCKET_NAME}/${SHORT_SHA}_test_log.xml
+        gcloud artifacts docker images delete us-central1-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/myimage:${SHORT_SHA}
+        gcloud run services delete helloworld-${SHORT_SHA} --region us-central1 --quiet

--- a/gradle-example/test.cloudbuild.yaml
+++ b/gradle-example/test.cloudbuild.yaml
@@ -3,11 +3,17 @@ steps:
   - id: test-builds-successfully
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     dir: gradle-example
-    script: |
-      gcloud builds submit --config cloudbuild.yaml
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gcloud builds submit --config cloudbuild.yaml
       
   - id: cleanup
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    script: |
-      gcloud container images delete gcr.io/${PROJECT_ID}/hello-spring
+    entrypoint: /bin/bash
+    args: 
+      - '-c'
+      - |
+        gcloud container images delete gcr.io/${PROJECT_ID}/hello-spring
       

--- a/multiple-node-versions-example/test.cloudbuild.yaml
+++ b/multiple-node-versions-example/test.cloudbuild.yaml
@@ -2,5 +2,8 @@ steps:
   - id: test-builds-successfully
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     dir: multiple-node-versions-example
-    script: |
-      gcloud builds submit --substitutions=_NODE_VERSION=17
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gcloud builds submit --substitutions=_NODE_VERSION=17

--- a/python-example-flask/test.cloudbuild.yaml
+++ b/python-example-flask/test.cloudbuild.yaml
@@ -2,19 +2,19 @@ steps:
   - id: test-builds-successfully
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     dir: python-example-flask/
-    env:
-      - 'SHORT_SHA=$SHORT_SHA'
-      - '_REPO_NAME=$_REPO_NAME'
-      - '_BUCKET_NAME=$_BUCKET_NAME'
-    script: |
-      gcloud builds submit --config cloudbuild.yaml \
-      --substitutions SHORT_SHA=${SHORT_SHA},_REPO_NAME=${_REPO_NAME},_BUCKET_NAME=${_BUCKET_NAME}
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gcloud builds submit --config cloudbuild.yaml \
+        --substitutions SHORT_SHA=${SHORT_SHA},_REPO_NAME=${_REPO_NAME},_BUCKET_NAME=${_BUCKET_NAME}
 
   - id: cleanup
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    env:
-      - 'SHORT_SHA=$SHORT_SHA'
-    script: |
-      gsutil rm gs://${_BUCKET_NAME}/${SHORT_SHA}_test_log.xml
-      gcloud artifacts docker images delete us-central1-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/myimage:${SHORT_SHA}
-      gcloud run services delete helloworld-${SHORT_SHA} --region us-central1 --quiet
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        gsutil rm gs://${_BUCKET_NAME}/${SHORT_SHA}_test_log.xml
+        gcloud artifacts docker images delete us-central1-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/myimage:${SHORT_SHA}
+        gcloud run services delete helloworld-${SHORT_SHA} --region us-central1 --quiet


### PR DESCRIPTION
The nightly tests have started failing.  Script mode isn't GA yet so I think some underlying functionality there has changed, causing the tests to fail.  Moving back to `entrypoint: /bin/bash`