### PR TITLE
Update java.security JVM arg

### DIFF
--- a/maven-example/Dockerfile
+++ b/maven-example/Dockerfile
@@ -15,4 +15,4 @@
 FROM openjdk:19-jdk-alpine
 ARG JAR_FILE=JAR_FILE_MUST_BE_SPECIFIED_AS_BUILD_ARG
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/urandom","-jar","/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/maven-example/Dockerfile
+++ b/maven-example/Dockerfile
@@ -15,4 +15,4 @@
 FROM openjdk:19-jdk-alpine
 ARG JAR_FILE=JAR_FILE_MUST_BE_SPECIFIED_AS_BUILD_ARG
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-Djava.security.edg=file:/dev/./urandom","-jar","/app.jar"]
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/urandom","-jar","/app.jar"]


### PR DESCRIPTION
Two quick changes to the java.security.egd (entropy gathering device) property we're setting on this line:
1) I believe we had the property slightly mixed up ("edg" instead of "egd")
2) We have an outdated workaround in the value we're setting, which is an interesting story.

Back in the day, the "/dev/./urandom" path was used to specify a number generation algorithm and as a workaround for cross platform reliability.
If you were on Windows or *nix systems it would resolve to different devices, and it would either choose SHA1PRNG or NativePRNG.
This value may still cause delays on Windows systems (I haven't tested), but that's not very relevant for us in any case.


Folks ([including Oracle](http://openjdk.java.net/jeps/123#:~:text=VERY%20difficult%20to%20explain%20to%20developers%20and%20customers)) found that this was confusing, so it was fixed/simplified by JDK 8 security enhancements and the changes it brought to the SecureRandom class.
As a result we [don't have to use the "/./" anymore](https://docs.oracle.com/javase/8/docs/technotes/guides/security/enhancements-8.html#:~:text=The%20obscure%20workaround%20using%20file%3A///dev/urandom%20and%20file%3A/dev/./urandom%20is%20no%20longer%20required).

It's [still possible to configure](http://openjdk.java.net/jeps/123) the number generation algorithm, but I don't think it's critical to our sample here.

If you're interested in reading further I'd start at the [initial bug](https://bugs.openjdk.java.net/browse/JDK-8046113) and look for further changes in later updates.