### PR TITLE
Simplify golang-sample bash and use latest version of go-junit-report

### DIFF
--- a/golang-sample/cloudbuild.yaml
+++ b/golang-sample/cloudbuild.yaml
@@ -20,10 +20,8 @@ steps:
     args: 
       - -c
       - |
-        go get github.com/jstemmer/go-junit-report
-        go install github.com/jstemmer/go-junit-report
-        2>&1 go test -timeout 1m -v ./... | tee sponge.log
-        /go/bin/go-junit-report -set-exit-code < sponge.log > ${SHORT_SHA}_test_log.xml
+        go install github.com/jstemmer/go-junit-report/v2@latest
+        2>&1 go test -timeout 1m -v ./... | /go/bin/go-junit-report -set-exit-code -iocopy -out ${SHORT_SHA}_test_log.xml
   # [END cloudbuild_go_test_yaml]
   
   # [START cloudbuild_go_image_yaml]


### PR DESCRIPTION
`go get` is no longer necessary. Its behaviour has changed and it's now
used to adjust dependencies in go.mod rather than downloading and
installing packages.

I've modified `go install` to install the latest major version (v2) of
github.com/jstemmer/go-junit-report, which is the version that's
actively being maintained. This new version has an `-iocopy` flag to
copy stdin directly to stdout, while writing the report to a separate
file. This removes the need to use `tee` for preserving the original `go
test` output.