### PR TITLE
Update example to use Artifact Registry

### DIFF
--- a/run-example-builddeploy/cloudbuild.yaml
+++ b/run-example-builddeploy/cloudbuild.yaml
@@ -16,13 +16,13 @@
 steps:
 # Build the container image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage', '.']
 # Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image']
+  args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage']
 # Deploy container image to Cloud Run
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['run', 'deploy', 'myservice', '--image', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+  args: ['run', 'deploy', 'myservice', '--image', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
 images:
-- us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image
+- us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage
 # [END cloudbuild_run_example_builddeploy]

--- a/run-example-builddeploy/cloudbuild.yaml
+++ b/run-example-builddeploy/cloudbuild.yaml
@@ -16,13 +16,13 @@
 steps:
 # Build the container image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/myimage', '.']
+  args: ['build', '-t', 'my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image', '.']
 # Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/myimage']
+  args: ['push', 'my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image']
 # Deploy container image to Cloud Run
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['run', 'deploy', 'myservice', '--image', 'gcr.io/$PROJECT_ID/myimage', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+  args: ['run', 'deploy', 'myservice', '--image', 'my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
 images:
-- gcr.io/$PROJECT_ID/myimage
+- my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image
 # [END cloudbuild_run_example_builddeploy]

--- a/run-example-builddeploy/cloudbuild.yaml
+++ b/run-example-builddeploy/cloudbuild.yaml
@@ -16,13 +16,13 @@
 steps:
 # Build the container image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image', '.']
 # Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image']
+  args: ['push', 'my_host_location-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image']
 # Deploy container image to Cloud Run
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['run', 'deploy', 'myservice', '--image', 'my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+  args: ['run', 'deploy', 'myservice', '--image', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
 images:
-- my_host_location-docker.pkg.dev/$PROJECT_ID/my_repository/my_image
+- us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image
 # [END cloudbuild_run_example_builddeploy]

--- a/run-example-builddeploy/cloudbuild.yaml
+++ b/run-example-builddeploy/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image', '.']
 # Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'my_host_location-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image']
+  args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image']
 # Deploy container image to Cloud Run
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['run', 'deploy', 'myservice', '--image', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/my_image', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']


### PR DESCRIPTION
Replace Container Registry examples where the user can push/pull from their own Artifact Registry repo instead.
Leave Container Registry in references to Docker as we still store Docker builder there.