### PR TITLE
Migrate to the Cloud SDK team's official image to use the gcloud CLI

### DIFF
--- a/run-example-builddeploy/cloudbuild.yaml
+++ b/run-example-builddeploy/cloudbuild.yaml
@@ -19,14 +19,14 @@ steps:
     args:
       - 'build'
       - '-t'
-      - '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage'
       - '.'
 
   # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
-      - '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage'
 
   # Deploy container image to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -34,18 +34,14 @@ steps:
     args:
       - 'run'
       - 'deploy'
-      - '${_SERVICE_NAME}'
+      - 'myservice'
       - '--image'
-      - '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage'
       - '--region'
-      - '${_REGION_NAME}'
+      - 'us-central1'
       - '--platform'
       - 'managed'
       - '--allow-unauthenticated'
-substitutions:
-  _REGION_NAME: us-west1
-  _REPO_NAME: container-images
-  _SERVICE_NAME: public-web-cloud-run
 images:
-- '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage'
 # [END cloudbuild_run_example_builddeploy]

--- a/run-example-builddeploy/cloudbuild.yaml
+++ b/run-example-builddeploy/cloudbuild.yaml
@@ -14,15 +14,38 @@
 
 # [START cloudbuild_run_example_builddeploy]
 steps:
-# Build the container image
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage', '.']
-# Push the container image to Container Registry
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage']
-# Deploy container image to Cloud Run
-- name: 'gcr.io/cloud-builders/gcloud'
-  args: ['run', 'deploy', 'myservice', '--image', 'us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+      - '.'
+
+  # Push the container image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+
+  # Deploy container image to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - '${_SERVICE_NAME}'
+      - '--image'
+      - '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
+      - '--region'
+      - '${_REGION_NAME}'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+substitutions:
+  _REGION_NAME: us-west1
+  _REPO_NAME: container-images
+  _SERVICE_NAME: public-web-cloud-run
 images:
-- us-central1-docker.pkg.dev/$PROJECT_ID/$_REPO_NAME/myimage
+- '${_REGION_NAME}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_SERVICE_NAME}'
 # [END cloudbuild_run_example_builddeploy]


### PR DESCRIPTION
This migration is suggested at [GoogleCloudPlatform/cloud-builders/gcloud/README.md](https://github.com/GoogleCloudPlatform/cloud-builders/blob/master/gcloud/README.md) and in the [official doc](https://cloud.google.com/build/docs/deploying-builds/deploy-cloud-run). Other changes in this commit:

* Parameterize the repeated region name so that u only have to change the region in one place.

* Split the `args` arrays into multiple lines for better readability

* All substituting variable values are centralized in the build config file