### PR TITLE
Add comments around example code

### DIFF
--- a/python-example-noncontainer-artifacts/cloudbuild.yaml
+++ b/python-example-noncontainer-artifacts/cloudbuild.yaml
@@ -46,8 +46,12 @@ artifacts:
     paths:
       - ${SHORT_SHA}_test_log.xml
 # [END cloudbuild_python_logs_yaml]
-# Store Python package in Google Artifact Registry 
+
+# [START cloudbuild_python_upload_yaml]
+# Store Python package in Artifact Registry
   pythonPackages:
     - repository: "https://us-central1-python.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_PYTHON_REPO}"
       paths: ["dist/*"]
+# [END cloudbuild_python_upload_yaml]
+   
 # [END cloudbuild_python_yaml]

--- a/python-example-noncontainer-artifacts/cloudbuild.yaml
+++ b/python-example-noncontainer-artifacts/cloudbuild.yaml
@@ -12,24 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START cloudbuild_python_yaml]
+
+# [START cloudbuild_python_dependencies_yaml]
+# Install dependencies
 steps:
   - name: python
     entrypoint: python
     args: ["-m", "pip", "install", "--upgrade", "pip"]
-
-  # [START cloudbuild_python_dependencies_yaml]
-  # Install dependencies
   - name: python
     entrypoint: python
     args: ["-m", "pip", "install", "build", "pytest", "Flask", "--user"]
-  # [END cloudbuild_python_dependencies_yaml]
-  
-  # [START cloudbuild_python_package_yaml]
-  # Python Build
-  - name: python
-    entrypoint: python
-    args: ["-m", "build"]
-  # [END cloudbuild_python_package_yaml]
+# [END cloudbuild_python_dependencies_yaml]
 
   # [START cloudbuild_python_tests_yaml]
   # Run unit tests
@@ -38,20 +31,33 @@ steps:
     args: ["-m", "pytest", "--junitxml=${SHORT_SHA}_test_log.xml"] 
   # [END cloudbuild_python_tests_yaml]
 
-# [START cloudbuild_python_logs_yaml]
-# Save test logs to Google Cloud Storage
-artifacts:
-  objects:
-    location: gs://${_BUCKET_NAME}/
-    paths:
-      - ${SHORT_SHA}_test_log.xml
-# [END cloudbuild_python_logs_yaml]
+  # [START cloudbuild_python_package_yaml]
+  # Python Build
+  - name: python
+    entrypoint: python
+    args: ["-m", "build"]
+  # [END cloudbuild_python_package_yaml]
 
-# [START cloudbuild_python_upload_yaml]
-# Store Python package in Artifact Registry
-  pythonPackages:
-    - repository: "https://us-central1-python.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_PYTHON_REPO}"
-      paths: ["dist/*"]
-# [END cloudbuild_python_upload_yaml]
+  # [START cloudbuild_python_upload_yaml]
+  # Store Python package in Artifact Registry
+    pythonPackages:
+      - repository: "https://us-central1-python.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_PYTHON_REPO}"
+        paths: ["dist/*"]
+  # [END cloudbuild_python_upload_yaml]
+
+  # [START cloudbuild_python_provenance_yaml]
+  # Add option to enable build provenance generation
+  options:
+    requestedVerifyOption: VERIFIED
+  # [END cloudbuild_python_provenance_yaml]
+
+  # [START cloudbuild_python_logs_yaml]
+  # Save test logs to Google Cloud Storage
+  artifacts:
+    objects:
+      location: gs://${_BUCKET_NAME}/
+      paths:
+        - ${SHORT_SHA}_test_log.xml
+  # [END cloudbuild_python_logs_yaml]
    
 # [END cloudbuild_python_yaml]


### PR DESCRIPTION
Add comments around the code that demonstrates how to configure Cloud Build to store your Python packages in Artifact Registry.  Using comments to include snippets in our docs.