### PR TITLE
chore(deps): pin sqlalchemy dep version to 1.4.46

### DIFF
--- a/sql-private-pool/requirements.txt
+++ b/sql-private-pool/requirements.txt
@@ -1,5 +1,5 @@
 flask==2.2.2
-sqlalchemy
+sqlalchemy==1.4.46
 cryptography
 
 

--- a/sql-proxy/requirements.txt
+++ b/sql-proxy/requirements.txt
@@ -1,5 +1,5 @@
 flask==2.2.2
-sqlalchemy
+sqlalchemy==1.4.46
 cryptography
 
 


### PR DESCRIPTION
SQLAlchemy recently had a major version release to [version 2.X.X](https://pypi.org/project/SQLAlchemy/) that introduces breaking changes. The Cloud SQL samples in this repo have unpinned sqlalchemy version deps, meaning that the latest version will get installed by default and not work with current samples that were built using version 1.4.X

Pinning the version back to oldest 1.4 version 1.4.46 will allow samples to work as shown until the samples are updated to use v2.