### PR TITLE
Migrate to eclipse-temurin:21-jdk-alpin

### DIFF
--- a/gradle-example/Dockerfile
+++ b/gradle-example/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:19-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpin
 ARG JAR_FILE=JAR_FILE_MUST_BE_SPECIFIED_AS_BUILD_ARG
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-Djava.security.edg=file:/dev/./urandom","-jar","/app.jar"]

--- a/gradle-example/Dockerfile
+++ b/gradle-example/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:21-jdk-alpin
+FROM eclipse-temurin:21-jdk-alpine
 ARG JAR_FILE=JAR_FILE_MUST_BE_SPECIFIED_AS_BUILD_ARG
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-Djava.security.edg=file:/dev/./urandom","-jar","/app.jar"]

--- a/maven-example/Dockerfile
+++ b/maven-example/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:21-jdk-alpin
+FROM eclipse-temurin:21-jdk-alpine
 ARG JAR_FILE=JAR_FILE_MUST_BE_SPECIFIED_AS_BUILD_ARG
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/maven-example/Dockerfile
+++ b/maven-example/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:19-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpin
 ARG JAR_FILE=JAR_FILE_MUST_BE_SPECIFIED_AS_BUILD_ARG
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
#### Background
* Please see Google-internal bug: [b/358663676](http://b/358663676)
* These samples are linked to from [Build, test, and containerize Java applications](https://cloud.google.com/build/docs/building/build-containerize-java#maven_2).

#### Changes in this pull-request
* Why go from JDK 19 to JDK 21? See https://javaalmanac.io/jdk/. 21 has long-term support. 19 does not and reached end of life on 2023-03-21.
* Why eclipse-temurin? It is one of the recommended images under the [deprecation notice here](https://hub.docker.com/_/openjdk).
