### PR TITLE
Add dependabot[bot] to trusted contributors

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -4,3 +4,4 @@ annotations:
 trustedContributors:
   - renovate-bot
   - dpebot
+  - dependabot[bot]


### PR DESCRIPTION
This change should support having the dependabot changes auto-run CI. 

This uses the trusted-contribution bot that comments the required `/gcbrun` comment to start Cloud Build tests. 

Automatic comments already happening for renovate-bot PRs: https://github.com/GoogleCloudPlatform/cloud-build-samples/pull/368#issuecomment-3594391679
Manual PR comment alternative: https://github.com/GoogleCloudPlatform/cloud-build-samples/pull/366#issuecomment-4028765184